### PR TITLE
Use `bundle exec rails s` to start the rails server

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ ORIGIN_KEY: "YOUR_ORIGIN_KEY_HERE"
 2. Start the rails server (and run any migrations if prompted):
 
 ```
-rails s
+bundle exec rails s
 ```
 
 3. Visit [http://localhost:8080/](http://localhost:8080/) (**app/views/checkouts/index.html.erb**) to select an integration type.


### PR DESCRIPTION
Using just `rails s` with rbenv was problematic:

```sh
$ rails s
Rails is not currently installed on this system. To get the latest version, simply type:

    $ sudo gem install rails

You can then rerun your "rails" command.
```

This doesn't make sense because I had just run `bundle install`.

Running `bundle exec rails s` spun up the server without any problem 👍 