### PR TITLE
Modify webhooks to only look at the first NotificationRequestItem

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,7 @@
 !/log/.keep
 !/tmp/.keep
 
-# Ignore uploaded files in development
+# Ignore uploaded files in development.
 /storage/*
 !/storage/.keep
 
@@ -40,3 +40,6 @@ vendor/bundle
 
 config/local_env.yml
 Gemfile.lock
+
+# Ignore project configuration in Rider IDE.
+.idea

--- a/app/models/checkout.rb
+++ b/app/models/checkout.rb
@@ -52,17 +52,17 @@ class Checkout
     def adyen_webhooks(notifications)
       hmacKey = ENV["ADYEN_HMAC_KEY"]
       validator = Adyen::Utils::HmacValidator.new
-      notifications.each do |notification|
-        validationItem =  notification["NotificationRequestItem"]
-        if validator.valid_notification_hmac?(validationItem, hmacKey)
-          puts validationItem["eventCode"]
-          puts validationItem["merchantReference"]
-        else
-          # In case of invalid hmac, do not send [accepted] response
-          raise "Invalid HMAC Signature"
-        end
+      # JSON and HTTP POST notifications always contain a single NotificationRequestItem object, see https://docs.adyen.com/development-resources/webhooks/understand-notifications#notification-structure
+      notification = notifications.first()["NotificationRequestItem"]
+      # We recommend to always validate the HMAC, see also https://docs.adyen.com/development-resources/webhooks/verify-hmac-signatures
+      if validator.valid_notification_hmac?(validationItem, hmacKey)
+        puts validationItem["eventCode"]
+        puts validationItem["merchantReference"]
+        "[accepted]"
+      else
+        # In case of invalid hmac, do not send [accepted] response
+        raise "Invalid HMAC Signature"
       end
-      "[accepted]"
     end
 
     private

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -8,14 +8,14 @@
   <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous" />
   <%= stylesheet_link_tag "application", media: "all", 'data-turbolinks-track': "reload" %>
 
-  <script src="https://checkoutshopper-live.adyen.com/checkoutshopper/sdk/5.23.0/adyen.js"
-      integrity="sha384-8mwva0PVlFlbNW204liDWLdWflXZVxk84ytAly86gczDok13tfs5q58WGQ7ROWZw"
-      crossorigin="anonymous"></script>
+  <script src="https://checkoutshopper-test.adyen.com/checkoutshopper/sdk/5.33.0/adyen.js"
+     integrity="sha384-mPMlkgVUT7jVJZT0sTSfe+M4uN1ArRf1Itg76PcI6Y+zPLDvjCnjmAyyjtak3269"
+     crossorigin="anonymous"></script>
 
   <link rel="stylesheet"
-      href="https://checkoutshopper-live.adyen.com/checkoutshopper/sdk/5.23.0/adyen.css"
-      integrity="sha384-y6jvSkH/EJ+EmVfUABibJST5Df3+PXlPuQveX3NigzwJmiNofEBsUXxbxoaEllaI"
-      crossorigin="anonymous">
+     href="https://checkoutshopper-test.adyen.com/checkoutshopper/sdk/5.33.0/adyen.css"
+     integrity="sha384-86hqIixzFjIoRoaNYg9pd4mtpn3HtgJmrpYiyTv+3DaGPF70VnRUbtK7MKLTLRd9"
+     crossorigin="anonymous"/>
     
   <title>Checkout Demo</title>
 </head>


### PR DESCRIPTION
Process first and only element in the NotificationItems array.

See [documentation](https://docs.adyen.com/development-resources/webhooks/understand-notifications#notification-structure).

> JSON and HTTP POST notifications always contain a single NotificationRequestItem object.
SOAP notifications may contain up to six NotificationRequestItem objects, in case the events triggering notifications happen within a very short period of time.


**Acceptance Criteria**
- Process first and only element in the NotificationItems array.