### PR TITLE
Webhook processing: 202 response with empty body

### DIFF
--- a/app/controllers/checkouts_controller.rb
+++ b/app/controllers/checkouts_controller.rb
@@ -51,6 +51,7 @@ class CheckoutsController < ApplicationController
   def adyen_webhooks
     notifications = params["notificationItems"]
     response = Checkout.adyen_webhooks(notifications)
-    render json: response
+    # Return 202 with empty body
+    render status: 202, body: ''
   end
 end

--- a/app/models/checkout.rb
+++ b/app/models/checkout.rb
@@ -59,7 +59,7 @@ class Checkout
         puts notification["eventCode"]
         puts notification["merchantReference"]
         # Send a 202 response with an empty body
-        return [202, {}, ['']]
+        "Ok"
       else
         # In case of invalid hmac
         raise "Invalid HMAC Signature"

--- a/app/models/checkout.rb
+++ b/app/models/checkout.rb
@@ -58,9 +58,10 @@ class Checkout
       if validator.valid_notification_hmac?(notification, hmacKey)
         puts notification["eventCode"]
         puts notification["merchantReference"]
-        "[accepted]"
+        # Send a 202 response with an empty body
+        [202, {}, ['']]
       else
-        # In case of invalid hmac, do not send [accepted] response
+        # In case of invalid hmac
         raise "Invalid HMAC Signature"
       end
     end

--- a/app/models/checkout.rb
+++ b/app/models/checkout.rb
@@ -59,7 +59,7 @@ class Checkout
         puts notification["eventCode"]
         puts notification["merchantReference"]
         # Send a 202 response with an empty body
-        [202, {}, ['']]
+        return [202, {}, ['']]
       else
         # In case of invalid hmac
         raise "Invalid HMAC Signature"


### PR DESCRIPTION
The latest approach to accepting webhooks requires sending the response code `202` and an empty response body.

This PR updates all webhook handlers to implement the new approach.